### PR TITLE
Changed to use Bearer Auth Header and added venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 database.db
+venv


### PR DESCRIPTION
To address #5 (0.19 changes).
In 0.19 the API has switched to use the bearer token auth rather than including the auth in the body of the payload.